### PR TITLE
updates prettier-extend

### DIFF
--- a/react.js
+++ b/react.js
@@ -12,8 +12,7 @@ const extendsList = [
     'plugin:import/typescript',
     'plugin:sonarjs/recommended',
     'plugin:prettier/recommended',
-    'prettier/@typescript-eslint',
-    'prettier/react',
+    'prettier',
 ]
 const reactRules = {
     'react-hooks/exhaustive-deps': 0,


### PR DESCRIPTION
'prettier/@typescript-eslint' and 'prettier/react' are now part of 'prettier'